### PR TITLE
Update build scripts for actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up OpenJDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up OpenJDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'adopt' # You can choose other OpenJDK distributions.
       - name: Build with Gradle
         run: ./gradlew build # Ensure your gradlew script is executable
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: NAE2
           path: build/libs/*.jar # Make sure this path matches the location of your build artifacts


### PR DESCRIPTION
Set the script's Upload Artifact to v4 so that the action runs successfully

Additional information
I have tested the build and an error occurs.
The build is probably failing because the version of AE2-UEL is out of date.
I tried to update the dependencies, but gave up because Curse Maven has not been updated.


