### PR TITLE
Fix Hard Dependency on MekEng

### DIFF
--- a/src/main/java/co/neeve/nae2/common/items/cells/DenseGasCell.java
+++ b/src/main/java/co/neeve/nae2/common/items/cells/DenseGasCell.java
@@ -2,6 +2,7 @@ package co.neeve.nae2.common.items.cells;
 
 import appeng.core.Api;
 import co.neeve.nae2.common.registration.definitions.Materials;
+import com.mekeng.github.common.ItemAndBlocks;
 import com.mekeng.github.common.me.data.IAEGasStack;
 import com.mekeng.github.common.me.storage.IGasStorageChannel;
 import net.minecraft.item.ItemStack;
@@ -21,5 +22,12 @@ public class DenseGasCell extends DenseCell<IAEGasStack> {
 	@Override
 	public int getTotalTypes(@NotNull ItemStack cellItem) {
 		return 15;
+	}
+
+	/**
+	 * Seperated out from the main Items registration class to prevent loading of MekEng classes
+	 */
+	public static ItemStack getBaseCell() {
+		return new ItemStack(ItemAndBlocks.GAS_CELL_1k);
 	}
 }

--- a/src/main/java/co/neeve/nae2/common/registration/definitions/Items.java
+++ b/src/main/java/co/neeve/nae2/common/registration/definitions/Items.java
@@ -23,7 +23,6 @@ import co.neeve.nae2.common.recipes.handlers.VoidConversionRecipe;
 import co.neeve.nae2.common.registration.registry.Registry;
 import co.neeve.nae2.common.registration.registry.interfaces.Definitions;
 import co.neeve.nae2.common.registration.registry.rendering.NoItemRendering;
-import com.mekeng.github.common.ItemAndBlocks;
 import it.unimi.dsi.fastutil.objects.Object2ObjectArrayMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.item.ItemStack;
@@ -86,10 +85,13 @@ public class Items implements Definitions<IItemDefinition> {
 				.features(Features.VOID_CELLS)
 				.build());
 
-		this.gasStorageCellVoid = this.registerById(
-			registry.item("gas_storage_cell_void", VoidGasCell::new)
-				.features(Features.VOID_CELLS, Features.DENSE_GAS_CELLS)
-				.build());
+		if (Features.DENSE_GAS_CELLS.isEnabled())
+			this.gasStorageCellVoid = this.registerById(
+				registry.item("gas_storage_cell_void", VoidGasCell::new)
+					.features(Features.VOID_CELLS)
+					.build());
+		else
+			this.gasStorageCellVoid = new ItemDefinition("gas_storage_cell_void", null);
 
 		var voidCells = new Object2ObjectArrayMap<String, IItemDefinition>();
 		if (this.storageCellVoid.isEnabled()) voidCells.put("item", this.storageCellVoid);
@@ -168,29 +170,37 @@ public class Items implements Definitions<IItemDefinition> {
 			.features(Features.DENSE_FLUID_CELLS)
 			.build());
 
-		this.storageCellGas256K = this.registerById(registry.item("storage_cell_gas_256k", () ->
-				new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_256K,
-					(int) Math.pow(2, 8)))
-			.features(Features.DENSE_GAS_CELLS)
-			.build());
+		if (Features.DENSE_GAS_CELLS.isEnabled()) {
+			this.storageCellGas256K = this.registerById(registry.item("storage_cell_gas_256k", () ->
+							new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_256K,
+									(int) Math.pow(2, 8)))
+					.features(Features.DENSE_GAS_CELLS)
+					.build());
 
-		this.storageCellGas1024K = this.registerById(registry.item("storage_cell_gas_1024k", () ->
-				new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_1024K,
-					(int) Math.pow(2, 10)))
-			.features(Features.DENSE_GAS_CELLS)
-			.build());
+			this.storageCellGas1024K = this.registerById(registry.item("storage_cell_gas_1024k", () ->
+							new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_1024K,
+									(int) Math.pow(2, 10)))
+					.features(Features.DENSE_GAS_CELLS)
+					.build());
 
-		this.storageCellGas4096K = this.registerById(registry.item("storage_cell_gas_4096k", () ->
-				new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_4096K,
-					(int) Math.pow(2, 12)))
-			.features(Features.DENSE_GAS_CELLS)
-			.build());
+			this.storageCellGas4096K = this.registerById(registry.item("storage_cell_gas_4096k", () ->
+							new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_4096K,
+									(int) Math.pow(2, 12)))
+					.features(Features.DENSE_GAS_CELLS)
+					.build());
 
-		this.storageCellGas16384K = this.registerById(registry.item("storage_cell_gas_16384k", () ->
-				new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_16384K,
-					(int) Math.pow(2, 14)))
-			.features(Features.DENSE_GAS_CELLS)
-			.build());
+			this.storageCellGas16384K = this.registerById(registry.item("storage_cell_gas_16384k", () ->
+							new DenseGasCell(Materials.MaterialType.CELL_GAS_PART_16384K,
+									(int) Math.pow(2, 14)))
+					.features(Features.DENSE_GAS_CELLS)
+					.build());
+		} else {
+			this.storageCellGas256K = new ItemDefinition("storage_cell_gas_256k", null);
+			this.storageCellGas1024K = new ItemDefinition("storage_cell_gas_1024k", null);
+			this.storageCellGas4096K = new ItemDefinition("storage_cell_gas_4096k", null);
+			this.storageCellGas16384K = new ItemDefinition("storage_cell_gas_16384k", null);
+		}
+
 
 		registry.addBootstrapComponent((IPostInitComponent) r -> {
 			var items = AEApi.instance().definitions().items();
@@ -217,12 +227,12 @@ public class Items implements Definitions<IItemDefinition> {
 			}
 
 			if (Features.DENSE_GAS_CELLS.isEnabled()) {
-				mirrorCellUpgrades(new ItemStack(ItemAndBlocks.GAS_CELL_1k), new IItemDefinition[]{
+				mirrorCellUpgrades(DenseGasCell.getBaseCell(), new IItemDefinition[]{
 					this.storageCellGas256K,
 					this.storageCellGas1024K,
 					this.storageCellGas4096K,
 					this.storageCellGas16384K,
-					this.storageCellVoid
+					this.gasStorageCellVoid
 				});
 			}
 		});


### PR DESCRIPTION
This PR fixes NAE2 having a hard dependency on Mekanism Energistics (and thus Mekanism).

This was due to two issues:
- The importing of the `ItemAndBlocks` class from MekEng in the `Items` registration class, fixed by moving the class usage into `DenseGasCell`
- The usage of `DenseGasCell` and `VoidGasCell` in registration, even when MekEng isn't loaded, as that causes crashes (even when the class usage is in a lambda (most likely due to the classes containing generics with and methods returning MekEng classes)