### PR TITLE
Fix PMT Buttons Missing in Interface Term in Obf Env

### DIFF
--- a/src/main/java/co/neeve/nae2/mixin/patternmultitool/client/pmthosts/MixinGuiInterfaceTerminal.java
+++ b/src/main/java/co/neeve/nae2/mixin/patternmultitool/client/pmthosts/MixinGuiInterfaceTerminal.java
@@ -80,16 +80,16 @@ public class MixinGuiInterfaceTerminal extends MixinAEBaseGui implements IPatter
 		at = @At(
 			value = "INVOKE",
 			target = "Ljava/util/List;clear()V",
-			shift = At.Shift.AFTER
-		), remap = false
-	)
+			shift = At.Shift.AFTER,
+			remap = false
+	))
 	public void injectDrawScreen(CallbackInfo ci) {
 		if (this.patternMultiToolButtons != null) {
 			this.buttonList.addAll(this.patternMultiToolButtons);
 		}
 	}
 
-	@Inject(method = "initGui", at = @At("RETURN"), remap = false)
+	@Inject(method = "initGui", at = @At("RETURN"))
 	private void injectButtons(CallbackInfo ci) {
 		this.initializePatternMultiTool();
 	}


### PR DESCRIPTION
This PR fixes PMT buttons missing from the Interface Terminal, due to misplaced `remap = false` values in Mixin Injections.

This PR ports the current Nomi Labs mixin fix for this issue, found in https://github.com/Nomi-CEu/Nomi-Labs/commit/b909614ae332ed87819f92163795d768b6c3d68d.

Fixes https://github.com/AE2-UEL/NAE2/issues/67